### PR TITLE
fix: update all imports to use relative paths and properly expose mod…

### DIFF
--- a/pymuco/AudioConverter.py
+++ b/pymuco/AudioConverter.py
@@ -17,10 +17,10 @@ import tempfile
 import wave
 from typing import List, Tuple, Union
 
-from MusicComputationNotation import MusicComputationNotation
-from NoteDuration import NoteDuration, NoteDurationMapping
-from NoteFrequencyConverter import NoteFrequencyConverter
-from ScientificPitchNotation import ScientificPitchNotation
+from .MusicComputationNotation import MusicComputationNotation
+from .NoteDuration import NoteDuration, NoteDurationMapping
+from .NoteFrequencyConverter import NoteFrequencyConverter
+from .ScientificPitchNotation import ScientificPitchNotation
 
 
 class AudioConverter:

--- a/pymuco/Chord.py
+++ b/pymuco/Chord.py
@@ -10,12 +10,12 @@
 # ------------------------------------------------------------------------------
 from enum import Enum
 
-from CircleOfFifths import CircleOfFifths
-from Enharmonic import Enharmonic
-from Interval import IntervalCalculator, IntervalName
-from KeySignature import KeySignature
-from MusicData import DEFAULT_OCTAVE, m
-from ScientificPitchNotation import ScientificPitchNotation
+from .CircleOfFifths import CircleOfFifths
+from .Enharmonic import Enharmonic
+from .Interval import IntervalCalculator, IntervalName
+from .KeySignature import KeySignature
+from .MusicData import DEFAULT_OCTAVE, m
+from .ScientificPitchNotation import ScientificPitchNotation
 
 
 class ChordType(Enum):

--- a/pymuco/CircleOfFifths.py
+++ b/pymuco/CircleOfFifths.py
@@ -10,10 +10,10 @@
 # ------------------------------------------------------------------------------
 from typing import List, Tuple
 
-from Enharmonic import Enharmonic
-from Interval import IntervalCalculator, IntervalName
-from MusicData import DEFAULT_OCTAVE, FLAT, SHARP, C, D, E, F, G
-from ScientificPitchNotation import ScientificPitchNotation
+from .Enharmonic import Enharmonic
+from .Interval import IntervalCalculator, IntervalName
+from .MusicData import DEFAULT_OCTAVE, FLAT, SHARP, C, D, E, F, G
+from .ScientificPitchNotation import ScientificPitchNotation
 
 
 class CircleOfFifths:

--- a/pymuco/Enharmonic.py
+++ b/pymuco/Enharmonic.py
@@ -8,9 +8,9 @@
 # Copyright:    Copyright © 2022-2023 German Margon. All rights reserved.
 # License:      BSD 3-Clause License, see LICENSE
 # ------------------------------------------------------------------------------
-from EnharmonicMapping import EnharmonicMapping
-from MusicData import DEFAULT_OCTAVE
-from ScientificPitchNotation import ScientificPitchNotation
+from .EnharmonicMapping import EnharmonicMapping
+from .MusicData import DEFAULT_OCTAVE
+from .ScientificPitchNotation import ScientificPitchNotation
 
 
 class Enharmonic:

--- a/pymuco/EnharmonicMapping.py
+++ b/pymuco/EnharmonicMapping.py
@@ -8,7 +8,7 @@
 # Copyright:    Copyright © 2022-2023 German Margon. All rights reserved.
 # License:      BSD 3-Clause License, see LICENSE
 # ------------------------------------------------------------------------------
-from MusicData import (
+from .MusicData import (
     DOUBLE_FLAT,
     DOUBLE_SHARP,
     FLAT,

--- a/pymuco/Interval.py
+++ b/pymuco/Interval.py
@@ -10,10 +10,10 @@
 # ------------------------------------------------------------------------------
 from enum import IntEnum
 
-from Enharmonic import Enharmonic
-from NoteFrequencyConverter import NoteFrequencyConverter
-from NoteMapping import NoteMapping
-from ScientificPitchNotation import ScientificPitchNotation
+from .Enharmonic import Enharmonic
+from .NoteFrequencyConverter import NoteFrequencyConverter
+from .NoteMapping import NoteMapping
+from .ScientificPitchNotation import ScientificPitchNotation
 
 
 class IntervalName(IntEnum):

--- a/pymuco/KeySignature.py
+++ b/pymuco/KeySignature.py
@@ -8,10 +8,10 @@
 # Copyright:    Copyright © 2022-2023 German Margon. All rights reserved.
 # License:      BSD 3-Clause License, see LICENSE
 # ------------------------------------------------------------------------------
-from CircleOfFifths import CircleOfFifths
-from Enharmonic import Enharmonic
-from MusicData import FLAT, MAJOR, MINOR, SHARP, M, m
-from ScientificPitchNotation import ScientificPitchNotation
+from .CircleOfFifths import CircleOfFifths
+from .Enharmonic import Enharmonic
+from .MusicData import FLAT, MAJOR, MINOR, SHARP, M, m
+from .ScientificPitchNotation import ScientificPitchNotation
 
 
 class KeySignature:

--- a/pymuco/MIDIUtils.py
+++ b/pymuco/MIDIUtils.py
@@ -8,8 +8,8 @@
 # Copyright:    Copyright © 2022-2023 German Margon. All rights reserved.
 # License:      BSD 3-Clause License, see LICENSE
 # ------------------------------------------------------------------------------
-from NoteMapping import NoteMapping
-from ScientificPitchNotation import ScientificPitchNotation
+from .NoteMapping import NoteMapping
+from .ScientificPitchNotation import ScientificPitchNotation
 
 
 class MIDINoteConverter:

--- a/pymuco/MidiGenerator.py
+++ b/pymuco/MidiGenerator.py
@@ -12,8 +12,8 @@ import logging
 
 from typing import List, Tuple
 
-from logging_utils import setup_logger
-from MIDIUtils import MIDINoteConverter
+from .logging_utils import setup_logger
+from .MIDIUtils import MIDINoteConverter
 
 
 class MidiGenerator:

--- a/pymuco/MusicComputationNotation.py
+++ b/pymuco/MusicComputationNotation.py
@@ -10,8 +10,8 @@
 # ------------------------------------------------------------------------------
 from typing import List, Tuple
 
-from NoteDuration import NoteDuration
-from ScientificPitchNotation import ScientificPitchNotation
+from .NoteDuration import NoteDuration
+from .ScientificPitchNotation import ScientificPitchNotation
 
 
 class MusicComputationNotation:

--- a/pymuco/NoteFrequencyConverter.py
+++ b/pymuco/NoteFrequencyConverter.py
@@ -8,8 +8,8 @@
 # Copyright:    Copyright © 2022-2023 German Margon. All rights reserved.
 # License:      BSD 3-Clause License, see LICENSE
 # ------------------------------------------------------------------------------
-from MIDIUtils import MIDINoteConverter
-from ScientificPitchNotation import ScientificPitchNotation
+from .MIDIUtils import MIDINoteConverter
+from .ScientificPitchNotation import ScientificPitchNotation
 
 
 class NoteFrequencyConverter:

--- a/pymuco/NoteMapping.py
+++ b/pymuco/NoteMapping.py
@@ -8,9 +8,9 @@
 # Copyright:    Copyright © 2022-2023 German Margon. All rights reserved.
 # License:      BSD 3-Clause License, see LICENSE
 # ------------------------------------------------------------------------------
-from Enharmonic import Enharmonic
-from MusicData import SHARP, B, C, E, MusicalAlphabet
-from ScientificPitchNotation import ScientificPitchNotation
+from .Enharmonic import Enharmonic
+from .MusicData import SHARP, B, C, E, MusicalAlphabet
+from .ScientificPitchNotation import ScientificPitchNotation
 
 _NOTE_NAME = MusicalAlphabet.get_note_name()
 

--- a/pymuco/Player.py
+++ b/pymuco/Player.py
@@ -10,8 +10,8 @@
 # ------------------------------------------------------------------------------
 import os
 
-from logging_utils import setup_logger
-from AudioConverter import AudioConverter
+from .logging_utils import setup_logger
+from .AudioConverter import AudioConverter
 
 
 class Player:

--- a/pymuco/Scale.py
+++ b/pymuco/Scale.py
@@ -11,13 +11,13 @@
 from enum import Enum
 from typing import List
 
-from CircleOfFifths import CircleOfFifths
-from Enharmonic import Enharmonic
-from KeySignature import KeySignature
-from MusicData import DEFAULT_OCTAVE, FLAT, MAJOR, MINOR, SHARP, A, C
-from NoteMapping import NoteMapping
-from ScientificPitchNotation import ScientificPitchNotation
-from Tonality import Tonality
+from .CircleOfFifths import CircleOfFifths
+from .Enharmonic import Enharmonic
+from .KeySignature import KeySignature
+from .MusicData import DEFAULT_OCTAVE, FLAT, MAJOR, MINOR, SHARP, A, C
+from .NoteMapping import NoteMapping
+from .ScientificPitchNotation import ScientificPitchNotation
+from .Tonality import Tonality
 
 
 class ScaleData(Enum):

--- a/pymuco/Tonality.py
+++ b/pymuco/Tonality.py
@@ -8,7 +8,7 @@
 # Copyright:    Copyright © 2022-2023 German Margon. All rights reserved.
 # License:      BSD 3-Clause License, see LICENSE
 # ------------------------------------------------------------------------------
-from ScientificPitchNotation import ScientificPitchNotation
+from .ScientificPitchNotation import ScientificPitchNotation
 
 
 class Tonality:

--- a/pymuco/__init__.py
+++ b/pymuco/__init__.py
@@ -1,0 +1,60 @@
+from .AudioConverter import AudioConverter
+from .Chord import Chord, ChordType
+from .CircleOfFifths import CircleOfFifths
+from .Enharmonic import Enharmonic
+from .EnharmonicMapping import EnharmonicMapping
+from .Interval import Interval
+from .KeySignature import KeySignature
+from .MIDIUtils import MIDINoteConverter
+from .MidiGenerator import MidiGenerator
+from .MusicComputationNotation import MusicComputationNotation
+from .MusicData import (
+    MusicalAlphabet,
+    Accidental,
+    NOTE_NAMES,
+    A, B, C, D, E, F, G,
+    ACCIDENTALS,
+    DOUBLE_SHARP, SHARP, NATURAL, FLAT, DOUBLE_FLAT,
+    DEFAULT_OCTAVE,
+    M, m,
+    MAJOR, MINOR
+)
+from .NoteDuration import NoteDuration
+from .NoteFrequencyConverter import NoteFrequencyConverter
+from .NoteMapping import NoteMapping
+from .Player import Player
+from .Scale import Scale
+from .ScientificPitchNotation import ScientificPitchNotation
+from .Tonality import Tonality
+
+__version__ = "1.1.2"
+
+__all__ = [
+    'AudioConverter',
+    'Chord',
+    'ChordType',
+    'CircleOfFifths',
+    'Enharmonic',
+    'EnharmonicMapping',
+    'Interval',
+    'KeySignature',
+    'MIDINoteConverter',
+    'MidiGenerator',
+    'MusicComputationNotation',
+    'MusicalAlphabet',
+    'Accidental',
+    'NOTE_NAMES',
+    'A', 'B', 'C', 'D', 'E', 'F', 'G',
+    'ACCIDENTALS',
+    'DOUBLE_SHARP', 'SHARP', 'NATURAL', 'FLAT', 'DOUBLE_FLAT',
+    'DEFAULT_OCTAVE',
+    'M', 'm',
+    'MAJOR', 'MINOR',
+    'NoteDuration',
+    'NoteFrequencyConverter',
+    'NoteMapping',
+    'Player',
+    'Scale',
+    'ScientificPitchNotation',
+    'Tonality',
+] 

--- a/pymuco/__init__.py
+++ b/pymuco/__init__.py
@@ -1,60 +1,79 @@
+# -*- coding: utf-8 -*-
+# ------------------------------------------------------------------------------
+# Name:         __init__.py
+# Purpose:      Pymuco Package
+#
+# Authors:      German Margon
+#
+# Copyright:    Copyright © 2022-2023 German Margon. All rights reserved.
+# License:      BSD 3-Clause License, see LICENSE
+# ------------------------------------------------------------------------------
 from .AudioConverter import AudioConverter
 from .Chord import Chord, ChordType
 from .CircleOfFifths import CircleOfFifths
 from .Enharmonic import Enharmonic
 from .EnharmonicMapping import EnharmonicMapping
-from .Interval import Interval
+from .Interval import Interval, IntervalCalculator, IntervalName
 from .KeySignature import KeySignature
 from .MIDIUtils import MIDINoteConverter
 from .MidiGenerator import MidiGenerator
 from .MusicComputationNotation import MusicComputationNotation
 from .MusicData import (
-    MusicalAlphabet,
-    Accidental,
-    NOTE_NAMES,
-    A, B, C, D, E, F, G,
     ACCIDENTALS,
-    DOUBLE_SHARP, SHARP, NATURAL, FLAT, DOUBLE_FLAT,
     DEFAULT_OCTAVE,
-    M, m,
-    MAJOR, MINOR
+    FLAT,
+    MAJOR,
+    MINOR,
+    M,
+    m,
+    NOTE_NAMES,
+    SHARP,
+    C,
+    G
 )
-from .NoteDuration import NoteDuration
+from .NoteDuration import NoteDuration, NoteDurationMapping
 from .NoteFrequencyConverter import NoteFrequencyConverter
 from .NoteMapping import NoteMapping
 from .Player import Player
-from .Scale import Scale
+from .Scale import Scale, ScaleData
 from .ScientificPitchNotation import ScientificPitchNotation
 from .Tonality import Tonality
 
 __version__ = "1.1.2"
 
 __all__ = [
-    'AudioConverter',
-    'Chord',
-    'ChordType',
-    'CircleOfFifths',
-    'Enharmonic',
-    'EnharmonicMapping',
-    'Interval',
-    'KeySignature',
-    'MIDINoteConverter',
-    'MidiGenerator',
-    'MusicComputationNotation',
-    'MusicalAlphabet',
-    'Accidental',
-    'NOTE_NAMES',
-    'A', 'B', 'C', 'D', 'E', 'F', 'G',
-    'ACCIDENTALS',
-    'DOUBLE_SHARP', 'SHARP', 'NATURAL', 'FLAT', 'DOUBLE_FLAT',
-    'DEFAULT_OCTAVE',
-    'M', 'm',
-    'MAJOR', 'MINOR',
-    'NoteDuration',
-    'NoteFrequencyConverter',
-    'NoteMapping',
-    'Player',
-    'Scale',
-    'ScientificPitchNotation',
-    'Tonality',
+    "AudioConverter",
+    "Chord",
+    "ChordType",
+    "CircleOfFifths",
+    "Enharmonic",
+    "EnharmonicMapping",
+    "Interval",
+    "IntervalCalculator",
+    "IntervalName",
+    "KeySignature",
+    "MIDINoteConverter",
+    "MidiGenerator",
+    "MusicComputationNotation",
+    "NoteDuration",
+    "NoteDurationMapping",
+    "NoteFrequencyConverter",
+    "NoteMapping",
+    "Player",
+    "Scale",
+    "ScaleData",
+    "ScientificPitchNotation",
+    "Tonality",
+    # Constants
+    "ACCIDENTALS",
+    "DEFAULT_OCTAVE",
+    "FLAT",
+    "MAJOR",
+    "MINOR",
+    "M",
+    "m",
+    "NOTE_NAMES",
+    "SHARP",
+    "C",
+    "G"
 ] 

--- a/pymuco/test/test_audio_converter.py
+++ b/pymuco/test/test_audio_converter.py
@@ -14,7 +14,7 @@ import unittest
 import wave
 from unittest.mock import MagicMock
 
-from AudioConverter import AudioConverter
+from pymuco import AudioConverter, ScientificPitchNotation
 
 
 class TestAudioConverter(unittest.TestCase):

--- a/pymuco/test/test_chord.py
+++ b/pymuco/test/test_chord.py
@@ -11,8 +11,7 @@
 # ------------------------------------------------------------------------------
 import unittest
 
-from Chord import Chord, ChordType
-from ScientificPitchNotation import ScientificPitchNotation
+from pymuco import Chord, ChordType, ScientificPitchNotation
 
 
 class TestChordType(unittest.TestCase):

--- a/pymuco/test/test_circle_of_fifths.py
+++ b/pymuco/test/test_circle_of_fifths.py
@@ -11,7 +11,7 @@
 # ------------------------------------------------------------------------------
 import unittest
 
-from CircleOfFifths import CircleOfFifths
+from pymuco import CircleOfFifths, ScientificPitchNotation
 
 
 class TestCircleOfFifths(unittest.TestCase):

--- a/pymuco/test/test_enharmonic.py
+++ b/pymuco/test/test_enharmonic.py
@@ -11,9 +11,11 @@
 # ------------------------------------------------------------------------------
 import unittest
 
-from Enharmonic import Enharmonic
-from MusicData import DEFAULT_OCTAVE
-from ScientificPitchNotation import ScientificPitchNotation
+from pymuco import (
+    Enharmonic,
+    DEFAULT_OCTAVE,
+    ScientificPitchNotation
+)
 
 
 class TestEnharmonic(unittest.TestCase):

--- a/pymuco/test/test_enharmonic_mapping.py
+++ b/pymuco/test/test_enharmonic_mapping.py
@@ -11,7 +11,7 @@
 # ------------------------------------------------------------------------------
 import unittest
 
-from EnharmonicMapping import EnharmonicMapping
+from pymuco import EnharmonicMapping, ScientificPitchNotation
 
 
 class TestEnharmonicMapping(unittest.TestCase):

--- a/pymuco/test/test_interval.py
+++ b/pymuco/test/test_interval.py
@@ -11,9 +11,15 @@
 # ------------------------------------------------------------------------------
 import unittest
 
-from Interval import Interval, IntervalCalculator, IntervalName
-from MusicData import DEFAULT_OCTAVE, C, G
-from ScientificPitchNotation import ScientificPitchNotation
+from pymuco import (
+    Interval,
+    IntervalCalculator,
+    IntervalName,
+    DEFAULT_OCTAVE,
+    C,
+    G,
+    ScientificPitchNotation
+)
 
 
 class TestIntervalName(unittest.TestCase):

--- a/pymuco/test/test_key_signature.py
+++ b/pymuco/test/test_key_signature.py
@@ -11,8 +11,7 @@
 # ------------------------------------------------------------------------------
 import unittest
 
-from KeySignature import KeySignature
-from ScientificPitchNotation import ScientificPitchNotation
+from pymuco import KeySignature, ScientificPitchNotation
 
 
 class TestKeySignature(unittest.TestCase):

--- a/pymuco/test/test_midi_generator.py
+++ b/pymuco/test/test_midi_generator.py
@@ -11,10 +11,13 @@
 # ------------------------------------------------------------------------------
 import unittest
 from unittest.mock import patch, mock_open
-from MidiGenerator import MidiGenerator
-from ScientificPitchNotation import ScientificPitchNotation
-from NoteDuration import NoteDuration
 from typing import List, Tuple
+
+from pymuco import (
+    MidiGenerator,
+    NoteDuration,
+    ScientificPitchNotation
+)
 
 
 class TestMidiGenerator(unittest.TestCase):

--- a/pymuco/test/test_midi_utils.py
+++ b/pymuco/test/test_midi_utils.py
@@ -12,8 +12,7 @@
 import re
 import unittest
 
-from MIDIUtils import MIDINoteConverter
-from ScientificPitchNotation import ScientificPitchNotation
+from pymuco import MIDINoteConverter, ScientificPitchNotation
 
 
 class TestMIDINoteConverter(unittest.TestCase):

--- a/pymuco/test/test_music_computation_notation.py
+++ b/pymuco/test/test_music_computation_notation.py
@@ -11,9 +11,11 @@
 # ------------------------------------------------------------------------------
 import unittest
 
-from MusicComputationNotation import MusicComputationNotation
-from NoteDuration import NoteDuration
-from ScientificPitchNotation import ScientificPitchNotation
+from pymuco import (
+    MusicComputationNotation,
+    NoteDuration,
+    ScientificPitchNotation
+)
 
 
 class TestMusicComputationNotation(unittest.TestCase):

--- a/pymuco/test/test_note_duration.py
+++ b/pymuco/test/test_note_duration.py
@@ -11,7 +11,7 @@
 # ------------------------------------------------------------------------------
 import unittest
 
-from NoteDuration import NoteDuration, NoteDurationMapping
+from pymuco import NoteDuration, NoteDurationMapping
 
 
 class TestNoteDurationMapping(unittest.TestCase):

--- a/pymuco/test/test_note_frequency_converter.py
+++ b/pymuco/test/test_note_frequency_converter.py
@@ -12,8 +12,7 @@
 import re
 import unittest
 
-from NoteFrequencyConverter import NoteFrequencyConverter
-from ScientificPitchNotation import ScientificPitchNotation
+from pymuco import NoteFrequencyConverter, ScientificPitchNotation
 
 
 class TestNoteFrequencyConverter(unittest.TestCase):

--- a/pymuco/test/test_note_mapping.py
+++ b/pymuco/test/test_note_mapping.py
@@ -11,7 +11,7 @@
 # ------------------------------------------------------------------------------
 import unittest
 
-from NoteMapping import NoteMapping
+from pymuco import NoteMapping, ScientificPitchNotation
 
 
 class TestNoteMapping(unittest.TestCase):

--- a/pymuco/test/test_player.py
+++ b/pymuco/test/test_player.py
@@ -12,11 +12,13 @@
 import unittest
 from unittest.mock import Mock
 
-from AudioConverter import AudioConverter
-from MusicComputationNotation import MusicComputationNotation
-from NoteDuration import NoteDuration
-from Player import Player
-from ScientificPitchNotation import ScientificPitchNotation
+from pymuco import (
+    Player,
+    AudioConverter,
+    MusicComputationNotation,
+    NoteDuration,
+    ScientificPitchNotation
+)
 
 
 class TestPlayer(unittest.TestCase):

--- a/pymuco/test/test_scale.py
+++ b/pymuco/test/test_scale.py
@@ -11,8 +11,7 @@
 # ------------------------------------------------------------------------------
 import unittest
 
-from Scale import Scale, ScaleData
-from ScientificPitchNotation import ScientificPitchNotation
+from pymuco import Scale, ScaleData, ScientificPitchNotation
 
 
 class TestScaleData(unittest.TestCase):

--- a/pymuco/test/test_scientific_pitch_notation.py
+++ b/pymuco/test/test_scientific_pitch_notation.py
@@ -11,8 +11,13 @@
 # ------------------------------------------------------------------------------
 import unittest
 
-from MusicData import ACCIDENTALS, DEFAULT_OCTAVE, NOTE_NAMES, C
-from ScientificPitchNotation import ScientificPitchNotation
+from pymuco import (
+    ACCIDENTALS,
+    DEFAULT_OCTAVE,
+    NOTE_NAMES,
+    C,
+    ScientificPitchNotation
+)
 
 
 class TestValidPitch(unittest.TestCase):

--- a/pymuco/test/test_tonality.py
+++ b/pymuco/test/test_tonality.py
@@ -11,8 +11,7 @@
 # ------------------------------------------------------------------------------
 import unittest
 
-from ScientificPitchNotation import ScientificPitchNotation
-from Tonality import Tonality
+from pymuco import Tonality, ScientificPitchNotation
 
 
 class TestTonality(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,22 @@
-from distutils.core import setup
+from setuptools import setup, find_packages
 
 with open("README.md", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
+with open("requirements.in", "r", encoding="utf-8") as fh:
+    requirements = [line.strip() for line in fh if line.strip() and not line.startswith("#")]
+
 setup(
     name="pymuco",
-    packages=["pymuco"],
+    packages=find_packages(),
     version="1.1.2",
     description="A Python Music Computation Library",
     author="German Margon",
     author_email="gmargon@pymuco.org",
     url="https://pymuco.org/",
     license="BSD-3-Clause",
+    install_requires=requirements,
+    python_requires=">=3.6",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "Intended Audience :: Developers",


### PR DESCRIPTION
## Changes
- Updated all internal imports to use relative paths (e.g., `from .Module import Class` instead of `from Module import Class`)
- Added proper module exposure in `__init__.py` to allow direct imports from the package
- Fixed import issues in various files including:
  - AudioConverter.py
  - Chord.py
  - CircleOfFifths.py
  - Enharmonic.py
  - EnharmonicMapping.py
  - Interval.py
  - KeySignature.py
  - MIDIUtils.py
  - MidiGenerator.py
  - MusicComputationNotation.py
  - NoteFrequencyConverter.py
  - NoteMapping.py
  - Player.py
  - Scale.py
  - Tonality.py